### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/Base/functions/source/admin-access-policy/admin-access-policy.template
+++ b/Base/functions/source/admin-access-policy/admin-access-policy.template
@@ -58,7 +58,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/functions/source/create-access-key/create-user-access-key.template
+++ b/Base/functions/source/create-access-key/create-user-access-key.template
@@ -53,7 +53,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/functions/source/create-key-pair/create-key-pair.template
+++ b/Base/functions/source/create-key-pair/create-key-pair.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/admin-access-policy.template
+++ b/Base/templates/admin-access-policy.template
@@ -58,7 +58,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/create-key-pair.template
+++ b/Base/templates/create-key-pair.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/create-user-access-key.template
+++ b/Base/templates/create-user-access-key.template
@@ -53,7 +53,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part2/templates/dev-environment.template
+++ b/Lab1/Part2/templates/dev-environment.template
@@ -54,7 +54,7 @@ Resources:
       FunctionName: check-role
       Description: Checks the existence of a given IAM role
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt CheckRoleLambdaRole.Arn
       Code:

--- a/Lab1/Part6/functions/source/restart-tasks/restart-tasks.template
+++ b/Lab1/Part6/functions/source/restart-tasks/restart-tasks.template
@@ -59,7 +59,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/functions/source/update-service/update-service.template
+++ b/Lab1/Part6/functions/source/update-service/update-service.template
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/apigateway/delete-api-gateways.template
+++ b/Lab1/Part6/templates/apigateway/delete-api-gateways.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/update/restart-tasks.template
+++ b/Lab1/Part6/templates/update/restart-tasks.template
@@ -62,7 +62,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/update/update-service.template
+++ b/Lab1/Part6/templates/update/update-service.template
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:


### PR DESCRIPTION
CloudFormation templates in aws-saas-factory-bootcamp have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.