### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/Lab2/Part4/templates/cloudwatch-lambda-function.template
+++ b/Lab2/Part4/templates/cloudwatch-lambda-function.template
@@ -74,7 +74,7 @@
             "Properties": {
                 "Description": "CloudWatchEventHandler",
                 "Handler": "index.handler",
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs10.x",
                 "Role": {"Fn::GetAtt" : ["LambdaRole", "Arn"] },
                 "Timeout": 240,
                 "Code": {


### PR DESCRIPTION
CloudFormation templates in aws-saas-factory-bootcamp have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.