### PR TITLE
update depracated nodejs version

### DIFF
--- a/Base/functions/source/admin-access-policy/admin-access-policy.template
+++ b/Base/functions/source/admin-access-policy/admin-access-policy.template
@@ -58,7 +58,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/functions/source/create-access-key/create-user-access-key.template
+++ b/Base/functions/source/create-access-key/create-user-access-key.template
@@ -53,7 +53,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/functions/source/create-key-pair/create-key-pair.template
+++ b/Base/functions/source/create-key-pair/create-key-pair.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/admin-access-policy.template
+++ b/Base/templates/admin-access-policy.template
@@ -58,7 +58,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/create-key-pair.template
+++ b/Base/templates/create-key-pair.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Base/templates/create-user-access-key.template
+++ b/Base/templates/create-user-access-key.template
@@ -53,7 +53,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part2/templates/dev-environment.template
+++ b/Lab1/Part2/templates/dev-environment.template
@@ -54,7 +54,7 @@ Resources:
       FunctionName: check-role
       Description: Checks the existence of a given IAM role
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Role: !GetAtt CheckRoleLambdaRole.Arn
       Code:

--- a/Lab1/Part6/functions/source/delete-api-gateways/delete-api-gateways.template
+++ b/Lab1/Part6/functions/source/delete-api-gateways/delete-api-gateways.template
@@ -55,7 +55,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/functions/source/restart-tasks/restart-tasks.template
+++ b/Lab1/Part6/functions/source/restart-tasks/restart-tasks.template
@@ -59,7 +59,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/functions/source/update-service/update-service.template
+++ b/Lab1/Part6/functions/source/update-service/update-service.template
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/apigateway/delete-api-gateways.template
+++ b/Lab1/Part6/templates/apigateway/delete-api-gateways.template
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/update/restart-tasks.template
+++ b/Lab1/Part6/templates/update/restart-tasks.template
@@ -62,7 +62,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:

--- a/Lab1/Part6/templates/update/update-service.template
+++ b/Lab1/Part6/templates/update/update-service.template
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Description: Invokes CFN with the required Attributes Neccesary
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt CFNExecRole.Arn
       Timeout: 300
       Code:


### PR DESCRIPTION
*Issue #, if available:*

no issue created.

When deploy `templates/saas-bootcamp-baseline-master`, following error occurs.

>The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 260249c3-748d-4d89-b011-53775f3a6026; Proxy: null)

Lambda runtime `nodejs8.10` is already deprecated.

*Description of changes:*

Updated runtime version to `nodejs12.x`.
Didn't inspect and change source code, but I went through all labs and it worked well.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
