### PR TITLE
update ruby version

### DIFF
--- a/Lab1/Part6/templates/client/web-client-build.template
+++ b/Lab1/Part6/templates/client/web-client-build.template
@@ -136,8 +136,8 @@ Resources:
                 - cd "${SERVICE_NAME}/src"
                 - sudo apt-get update && sudo apt-get install -y python-software-properties
                 - sudo apt-add-repository -y ppa:brightbox/ruby-ng
-                - sudo apt-get update && sudo apt-get install -y ruby2.2 ruby2.2-dev
-                - sudo gem2.2 install compass
+                - sudo apt-get update && sudo apt-get install -y ruby2.6 ruby2.6-dev
+                - sudo gem2.6 install compass
                 - sudo npm install && sudo npm install grunt-cli && sudo npm install bower
                 - ./node_modules/bower/bin/bower install --allow-root
             build:


### PR DESCRIPTION
*Issue #, if available:*

no issue created.

When deploy templates/saas-bootcamp-baseline-master, following error occurs.
Building web application fails.

>Running command sudo gem2.2 install compass
ERROR:  Error installing compass:
ffi requires Ruby version >= 2.3.

It uses too old Ruby version.

*Description of changes:*

Updated ruby from 2.2 to 2.6
Didn't inspect and change source code, but I went through all labs and it worked well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
