### PR TITLE
Fixed node-fetch version

### DIFF
--- a/source/auth-manager/package.json
+++ b/source/auth-manager/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "amazon-cognito-identity-js": "latest",
     "amazon-cognito-js": "latest",
-    "node-fetch": "latest",
+    "node-fetch": "2.x",
     "body-parser": "latest",
     "config": "latest",
     "express": "latest",


### PR DESCRIPTION
*Issue #, if available:*
#64 Auth manager service failed to start

*Description of changes:*
Fixed node-fetch version to 2.x so that it can be executed in Node.js 10.x environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
