### PR TITLE
GitHub Action to copy assets to default workshop bucket on commits

### DIFF
--- a/.github/workflows/copy-to-s3.yaml
+++ b/.github/workflows/copy-to-s3.yaml
@@ -1,0 +1,29 @@
+---
+name: Copy to S3
+on:
+  push:
+    branches:
+      - master
+env:
+  AWS_DEFAULT_REGION: us-west-2
+  AWS_DEFAULT_OUTPUT: json
+jobs:
+  copy-to-s3:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub’s OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-west-2
+        ## the following creates an ARN based on the values entered into github secrets
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+    - name: Copy files to S3
+      run: |
+        aws s3 sync . s3://aws-bootcamp-us-east-1 --exclude "*" --include "resources/*" --include "source/*" --acl authenticated-read --delete
+...


### PR DESCRIPTION
GitHub Action that checks out the main branch and copies the resources and source assets to the default workshop S3 bucket for easy deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
