### PR TITLE
Updated deploy.sh scripts to remove regional extension

### DIFF
--- a/Lab2/Part1/product-manager/deploy.sh
+++ b/Lab2/Part1/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then

--- a/Lab2/Part2/product-manager/deploy.sh
+++ b/Lab2/Part2/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then

--- a/Lab2/Part3/product-manager/deploy.sh
+++ b/Lab2/Part3/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then

--- a/Lab3/Part1/product-manager/deploy.sh
+++ b/Lab3/Part1/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then

--- a/Lab3/Part4/product-manager/deploy.sh
+++ b/Lab3/Part4/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then

--- a/Lab3/Part5/product-manager/deploy.sh
+++ b/Lab3/Part5/product-manager/deploy.sh
@@ -22,7 +22,7 @@ print_dots () {
 AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
 CODEBUILD_PROJECT="saas-bootcamp-product-svc"
 CODE_PIPELINE="saas-bootcamp-product-svc"
-BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket-${AWS_REGION}" | jq -r '.Parameter.Value')
+BOOTCAMP_BUCKET=$(aws ssm get-parameter --name "saas-bootcamp-bucket" | jq -r '.Parameter.Value')
 DEPLOY_MONITOR_QUEUE=$(aws ssm get-parameter --name "saas-bootcamp-ci-cd-queue-${AWS_REGION}" | jq -r '.Parameter.Value')
 
 if [ -z "$BOOTCAMP_BUCKET" ]; then


### PR DESCRIPTION
Updated deploy.sh scripts to remove regional extension for BOOTCAMP_BUCKET variables.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
